### PR TITLE
Patch 1

### DIFF
--- a/src/lib/ngx-skycons.component.ts
+++ b/src/lib/ngx-skycons.component.ts
@@ -511,9 +511,13 @@ export class SkyconsComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.ctx = this.canvas.nativeElement;
-    this.add(this.ctx);
-    this.play();
+    
+    // This avoids the nativeElement undefined error when upgrading to Angular 9
+    if (this.canvas !== undefined)
+      this.ctx = this.canvas.nativeElement;
+      this.add(this.ctx);
+      this.play();
+    }
   }
 
   add(el) {

--- a/src/lib/ngx-skycons.component.ts
+++ b/src/lib/ngx-skycons.component.ts
@@ -511,13 +511,9 @@ export class SkyconsComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    
-    // This avoids the nativeElement undefined error when upgrading to Angular 9
-    if (this.canvas !== undefined)
-      this.ctx = this.canvas.nativeElement;
-      this.add(this.ctx);
-      this.play();
-    }
+    this.ctx = this.canvas.nativeElement;
+    this.add(this.ctx);
+    this.play();
   }
 
   add(el) {

--- a/src/lib/ngx-skycons.component.ts
+++ b/src/lib/ngx-skycons.component.ts
@@ -511,9 +511,12 @@ export class SkyconsComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    this.ctx = this.canvas.nativeElement;
-    this.add(this.ctx);
-    this.play();
+    // This avoids the nativeElement undefined error when upgrading to Angular 9
+    if (this.canvas !== undefined)  {
+      this.ctx = this.canvas.nativeElement;
+      this.add(this.ctx);
+      this.play();
+    }
   }
 
   add(el) {


### PR DESCRIPTION
On ngAfterViewInit() added an if check to only execute logic if this.canvas is defined. This resolves the "nativeElement undefined" error reported on every reference to <sc-skycons> in the html while results are still being returned. Error was seen after upgrading to Angular 9, possibly related to changes to ViewChild.